### PR TITLE
 (master): fix issue with unshift not correclty setting prev and next

### DIFF
--- a/lib/Linkd.js
+++ b/lib/Linkd.js
@@ -623,7 +623,7 @@
 				node.nextNode = this.lastNode;
 				node.previousNode = null;
 			}
-			else node = new this.Node(hash, value, null, this.lastNode);
+      else node = new this.Node(hash, value, this.lastNode, null);
 
 
 			// remove existing instances
@@ -635,7 +635,9 @@
 
 
 			// set myself as nextnode
-			if (this.lastNode) this.lastNode.previousNode = node;
+      if (this.lastNode) {
+        this.lastNode.nextNode = node;
+      }
 
 
 			// set as first node


### PR DESCRIPTION
I was encountering an issue where `unshift` was not setting the previous and next nodes the way I expected it to. If I'm understanding how you intended this to function, I think I have a potential fix for it:

 - Line 626 was adding the `lastNode` to the `nextNode`, not the `previousNode` (assuming `unshift` is adding to the end of the list, I'm guessing it should add to the `previousNode`)
 - Similarly, in line 638, the `lastNode`'s `previousNode` prop was being set, not its `nextNode` prop.

Since the setting of the nodes to `previous` and not `next` appear to be in harmony, maybe my head is just in the wrong place, and I'm not grokking what you intended here. But, maybe it's a legitimate issue, too. 